### PR TITLE
switch to mbtileserver-watcher instead of inotify-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ Parameters for the helm chart.
 | `commandArgs`          | Arguments mbtileserver is called with            | `{--enable-reload-signal, -d, /data}` |
 | `reload.enabled`       | Enable reload                                    | `true`                                |
 | `reload.watchPath`     | The path where changes should result in a reload | `/data`                               |
+
+helm upgrade --install openftth-routenetwork-tileserver mbtileserver \
+  --version 2.2.0 \
+  --namespace openftth \
+  --set service.type=NodePort \
+  --set storage.size=1Gi \
+  --set 'commandArgs={--enable-reload-signal, --disable-preview, -d, /data}'

--- a/mbtileserver/Chart.yaml
+++ b/mbtileserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mbtileserver
 appVersion: "0.7.0"
 description: A Helm chart for mbtileserver
-version: 2.2.0
+version: 3.0.0
 type: application

--- a/mbtileserver/templates/deployment.yaml
+++ b/mbtileserver/templates/deployment.yaml
@@ -48,8 +48,8 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
         {{ if (eq .Values.reload.enabled true) }}
-        - name: {{ .Release.Name }}-{{ .Chart.Name }}-inotify
-          image: openftth/inotify-tools:v3.20.11.0-r0
+        - name: mbtileserver-watcher-sidecar
+          image: {{ .Values.reload.image }}:{{ .Values.reload.tag }}
           {{ if (eq .Values.storage.enabled true) }}
           volumeMounts:
             - name: {{ .Release.Name }}-{{ .Chart.Name }}-data
@@ -59,9 +59,7 @@ spec:
             capabilities:
               add:
                 - SYS_PTRACE
-          command:
-            - "/bin/sh"
-            - "-c"
-            - "while inotifywait --include '.*.mbtiles' {{ .Values.reload.watchPath }} -e create,delete,modify; do { kill -HUP $(pgrep mbtileserver); }; done"
+          args:
+            - "{{ .Values.reload.watchPath }}"
         {{ end }}
       restartPolicy: Always

--- a/mbtileserver/values.yaml
+++ b/mbtileserver/values.yaml
@@ -9,6 +9,8 @@ storage:
   path: /data
 
 reload:
+  image: openftth/mbtileserver-watcher
+  tag: v1.0.0
   enabled: true
   watchPath: /data
 


### PR DESCRIPTION
We have had issues with inotify-tools on AKS, so we have decided to write a simple sidecar-container to watch and reload mbtileserver if `.mbtiles` are updated.